### PR TITLE
Support for RadioHead's RHReliableDatagram protocol

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,4 +12,9 @@ set(ABSTRACTION_FILES
         src/SD.cpp
         )
 
+if (${BUILD_LINUX_RH_SERIAL})
+    # The RH_SERIAL transport uses RadioHead - be sure this module knows it.
+    add_definitions(-DRH_PLATFORM)
+endif (${BUILD_LINUX_RH_SERIAL})
+
 add_library(arduino-linux-abstraction ${ABSTRACTION_FILES})

--- a/src/Arduino.cpp
+++ b/src/Arduino.cpp
@@ -31,11 +31,12 @@ void SerialLinux::println(const char *toPrint) {
 int64_t timerValue = 0;
 bool timerValueCalled = false;
 
+
+#ifndef RH_PLATFORM
+
 void resetTimerValue() {
     timerValueCalled = false;
 }
-
-#ifndef RH_PLATFORM
 
 int64_t millis() {
     if (!timerValueCalled) {

--- a/src/Arduino.h
+++ b/src/Arduino.h
@@ -19,11 +19,11 @@
 #include <cstdlib>
 
 #ifndef RH_PLATFORM
+extern void resetTimerValue();
+
 extern void delay(uint64_t time);
 
 extern int64_t millis();
-
-extern void resetTimerValue();
 #endif
 
 

--- a/src/Arduino.h
+++ b/src/Arduino.h
@@ -18,14 +18,14 @@
 #include <chrono>
 #include <cstdlib>
 
-extern void resetTimerValue();
 #ifndef RH_PLATFORM
 extern void delay(uint64_t time);
 
 extern int64_t millis();
-#endif
 
 extern void resetTimerValue();
+#endif
+
 
 extern int64_t random(int64_t min, int64_t max);
 


### PR DESCRIPTION
This PR is a sub-module modification for the primary changes made in linux-mqtt-sn-gateway.

The primary purpose of this PR is to add support for using RadioHead's serial protocol on a serial port via the new RHSerialSocket class. To support this, RHReliableDatagramSocket and RHDatagramSocket were also created. Unless you pre-existing code that requires RHDatagram as your manager, RHReliableDatagramSocket is preffered, as it can talk to both protocols by simply switching on/off "reliable" mode.

The Transmission protocol identifier RH_SERIAL was added to the list identifiers that can be passed to CMake.

This PR was made for and tested on my primary use case: an MQTT-SN gateway on a Raspberry Pi. As part of this, the Gateway code made more robust and fault tolerant. Terminating a thread due to an error condition now throws the catchable exception LinuxSystem::ThreadTerminated. In response to that, the gateway now shuts down gracefully when sockets are lost or endpoints are not set up correctly. Finally, I added some logger messages to the early begin() and init() procedures to help diagnose setup errors, and I cleaned up a compiler warnings in the core.